### PR TITLE
Python3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,8 @@ language: python
 python:
     - "2.6"
     - "2.7"
-before_install:
-    - sudo apt-get update -qq
-    - sudo apt-get install -qq swig
+    - "3.4"
+    - "3.5"
 install:
-    - pip install -r requirements.txt --use-mirrors
-    # SSLv2 was removed from OpenSSL since the latest M2Crypto release...
-    - pip install --upgrade git+https://github.com/msabramo/M2Crypto.git@1de89f579e5377412fd428fb96edbfd3ef4e5c4d
+    - pip install -r requirements.txt
 script: python setup.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-    - "2.6"
     - "2.7"
     - "3.4"
     - "3.5"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Replaced use of M2Crypto with Cryptography library
 * Added python3 support
+* Drop support for python 2.6
 
 ## 0.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Dev
+
+* Replaced use of M2Crypto with Cryptography library
+* Added python3 support
+
 ## 0.1.0
 
 * Added a timeout parameter to verify() and get_ticket_data(). Defaults

--- a/auth_tkt/compat.py
+++ b/auth_tkt/compat.py
@@ -1,0 +1,23 @@
+from base64 import b64decode, b64encode
+
+import six
+
+
+def base64encode(s, encoding='utf-8'):
+    if six.PY2:
+        return b64encode(s)
+    return b64encode(bytes(s, encoding)).decode()
+
+
+def base64decode(s, encoding='utf-8'):
+    if six.PY2:
+        return b64decode(s)
+    return b64decode(s).decode(encoding)
+
+
+def to_bytes(s, encoding='utf-8'):
+    if six.PY2:
+        if isinstance(s, unicode):
+            return s.encode(encoding)
+        return s
+    return bytes(s, encoding)

--- a/auth_tkt/compat.py
+++ b/auth_tkt/compat.py
@@ -1,22 +1,24 @@
 from base64 import b64decode, b64encode
+import sys
 
-import six
+
+IS_PY2 = (sys.version_info.major == 2)
 
 
 def base64encode(s, encoding='utf-8'):
-    if six.PY2:
+    if IS_PY2:
         return b64encode(s)
     return b64encode(bytes(s, encoding)).decode()
 
 
 def base64decode(s, encoding='utf-8'):
-    if six.PY2:
+    if IS_PY2:
         return b64decode(s)
     return b64decode(s).decode(encoding)
 
 
 def to_bytes(s, encoding='utf-8'):
-    if six.PY2:
+    if IS_PY2:
         if isinstance(s, unicode):
             return s.encode(encoding)
         return s

--- a/auth_tkt/encrypted.py
+++ b/auth_tkt/encrypted.py
@@ -1,33 +1,42 @@
+import base64
 from gzip import zlib
 import hashlib
 import hmac
 import json
+import os
 
-from M2Crypto import EVP, Rand
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives.ciphers import algorithms, Cipher, modes
 
+from auth_tkt.compat import to_bytes
 from auth_tkt.ticket import AuthTkt
 
 
+BACKEND = default_backend()
+
+
 class DecryptionError(Exception):
-    """
-    Failed to decrypt. Can happen with wrong password, for example.
-    """
+    """Failed to decrypt. Can happen with wrong password, for example."""
+    pass
 
 
 class EncryptedAuthTkt(object):
 
     @staticmethod
-    def from_data(authtkt_secret, payload_secret, uid, data=None, ip='0.0.0.0',
-                  tokens=(), base64=True, ts=None):
-        payload_secret = str(payload_secret)
-        data = _encrypt_userdata(data or {}, payload_secret)
-        auth_ticket = AuthTkt(authtkt_secret, uid, data, ip, tokens, base64,
-                              ts)
+    def from_data(
+            authtkt_secret, payload_secret, uid, data=None, ip='0.0.0.0',
+            tokens=(), base64=True, ts=None, encoding='utf-8'):
+        data = json.dumps(data or {})
+        data = _encrypt_userdata(
+            to_bytes(data, encoding), to_bytes(payload_secret, encoding))
+        auth_ticket = AuthTkt(
+            authtkt_secret, uid, data, ip, tokens, base64, ts,
+            encoding=encoding)
         return EncryptedAuthTkt(auth_ticket, payload_secret)
 
     def __init__(self, auth_ticket, payload_secret):
         self.auth_ticket = auth_ticket
-        self._payload_secret = str(payload_secret)
+        self._payload_secret = to_bytes(payload_secret)
 
     @property
     def uid(self):
@@ -35,7 +44,8 @@ class EncryptedAuthTkt(object):
 
     @property
     def data(self):
-        return _decrypt_userdata(self.auth_ticket.data, self._payload_secret)
+        return json.loads(_decrypt_userdata(
+            self.auth_ticket.data, self._payload_secret).decode())
 
     def ticket(self):
         return self.auth_ticket.ticket()
@@ -49,44 +59,44 @@ class EncryptedAuthTkt(object):
 
 def _derive_keys(secret, salt=None):
     if salt is None:
-        salt = Rand.rand_bytes(32)
+        salt = os.urandom(32)
 
     # derive 256 bit encryption key using the pbkdf2 standard
-    key = EVP.pbkdf2(secret, salt, iter=1000, keylen=32)
+    key = hashlib.pbkdf2_hmac(
+        'sha1', secret, salt, 1000, dklen=32)
 
     # Derive encryption key and HMAC key from it
     # See Practical Cryptography section 8.4.1.
-    hmacKey = hashlib.sha256(key + 'MAC').digest()
-    encKey = hashlib.sha256(key + 'encrypt').digest()
+    hmacKey = hashlib.sha256(key + b'MAC').digest()
+    encKey = hashlib.sha256(key + b'encrypt').digest()
 
     return hmacKey, encKey, salt
 
 
 def _encrypt_userdata(cleartext, secret):
-    cleartext = json.dumps(cleartext)
-
     hmacKey, encKey, salt = _derive_keys(secret)
 
     # get 128 bit random iv
-    iv = Rand.rand_bytes(16)
+    iv = os.urandom(16)
 
     # Add HMAC to cleartext so that we can check during decrypt if we got
     # the right cleartext back. We are doing sign-then-encrypt, which lets
     # us encrypt empty cleartext (otherwise we'd need to pad with some
     # string to encrypt). Practical Cryptography by Schneier & Ferguson
     # also recommends doing it in this order in section 8.2.
-    mac = hmac.new(
-        hmacKey, cleartext + iv + salt, hashlib.sha256).hexdigest()
-
-    ciphertext = _encipher(zlib.compress(cleartext + mac), encKey, iv,
-                           'aes_128_ofb')
+    mac = hmac.new(hmacKey, cleartext + iv + salt, hashlib.sha256).hexdigest()
+    ciphertext = _encipher(
+        zlib.compress(cleartext + to_bytes(mac)), encKey, iv, algorithms.AES)
 
     return (
-        iv + salt + ciphertext).encode('base64').strip().replace('\n', '')
+        base64.b64encode(iv + salt + ciphertext)
+        .strip()
+        .replace(b'\n', b'')
+    )
 
 
 def _decrypt_userdata(ciphertext, secret):
-    ciphertext = ciphertext.decode('base64')
+    ciphertext = base64.b64decode(ciphertext)
     iv, salt, ciphertext = (
         ciphertext[:16], ciphertext[16:48], ciphertext[48:])
 
@@ -94,28 +104,31 @@ def _decrypt_userdata(ciphertext, secret):
 
     # decrypt
     try:
-        ret = zlib.decompress(_decipher(ciphertext, encKey, iv, 'aes_128_ofb'))
-    except (zlib.error, EVP.EVPError), e:
+        ret = zlib.decompress(_decipher(
+            ciphertext, encKey, iv, algorithms.AES))
+    except (zlib.error, ValueError) as e:
         raise DecryptionError(str(e))
 
     # Check MAC
     mac = ret[-64:]
     ret = ret[:-64]
-    if hmac.new(hmacKey, ret + iv + salt,
-                hashlib.sha256).hexdigest() != mac:
-        raise DecryptionError('HMAC does not match')
 
-    return json.loads(ret)
+    if hmac.new(hmacKey, ret + iv + salt,
+                hashlib.sha256).hexdigest() != mac.decode():
+        raise DecryptionError('HMAC does not match')
+    return ret
 
 
 def _decipher(ciphertext, key, iv, alg):
-    return _cipherFilter(alg, key, iv, 0, ciphertext)
+    return _cipherFilter(alg, key, iv, ciphertext, decrypt=True)
 
 
 def _encipher(plaintext, key, iv, alg):
-    return _cipherFilter(alg, key, iv, 1, plaintext)
+    return _cipherFilter(alg, key, iv, plaintext)
 
 
-def _cipherFilter(alg, key, iv, op, input_):
-    cipher = EVP.Cipher(alg=alg, key=key, iv=iv, op=op)
-    return cipher.update(input_) + cipher.final()
+def _cipherFilter(alg, key, iv, input_, decrypt=False):
+    key = key[:16]  # required for AES 128
+    cipher = Cipher(alg(key), modes.OFB(iv), backend=BACKEND)
+    cipher = cipher.decryptor() if decrypt else cipher.encryptor()
+    return cipher.update(input_) + cipher.finalize()

--- a/auth_tkt/encrypted.py
+++ b/auth_tkt/encrypted.py
@@ -6,7 +6,9 @@ import json
 import os
 
 from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.ciphers import algorithms, Cipher, modes
+from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
 
 from auth_tkt.compat import to_bytes
 from auth_tkt.ticket import AuthTkt
@@ -62,8 +64,9 @@ def _derive_keys(secret, salt=None):
         salt = os.urandom(32)
 
     # derive 256 bit encryption key using the pbkdf2 standard
-    key = hashlib.pbkdf2_hmac(
-        'sha1', secret, salt, 1000, dklen=32)
+    key = PBKDF2HMAC(
+        algorithm=hashes.SHA1, length=32, salt=salt, iterations=1000,
+        backend=BACKEND).derive(secret)
 
     # Derive encryption key and HMAC key from it
     # See Practical Cryptography section 8.4.1.

--- a/auth_tkt/helpers.py
+++ b/auth_tkt/helpers.py
@@ -3,10 +3,11 @@ from auth_tkt.ticket import validate
 
 
 def get_ticket_data(ticket, authtkt_secret, crypted_cookie_secret=None,
-                    timeout=7200):
+                    timeout=7200, encoding='utf-8'):
     """We store user information in our session hashes. You can retreive that
     data with this function."""
-    ticket = validate(ticket, authtkt_secret, timeout=timeout)
+    ticket = validate(
+        ticket, authtkt_secret, timeout=timeout, encoding=encoding)
 
     if not ticket:
         return None

--- a/auth_tkt/ticket.py
+++ b/auth_tkt/ticket.py
@@ -9,7 +9,12 @@ import socket
 import struct
 from time import time
 
-from six.moves import http_cookies
+try:
+    # Python 2
+    import Cookie as http_cookies
+except ImportError:
+    # Python 3
+    import http.cookies as http_cookies
 
 from auth_tkt.compat import base64decode, base64encode, to_bytes
 

--- a/auth_tkt/ticket.py
+++ b/auth_tkt/ticket.py
@@ -1,16 +1,20 @@
 # Copyright (c) 2009-2013, Yola, Inc.
 # Copyright (c) 2005, Imaginary Landscape LLC and Contributors
-# The AuthTkt class is derived from Ian Bicking's Python port (now shipped with mod_auth_tkt)
+# The AuthTkt class is derived from Ian Bicking's Python port (now shipped
+# with mod_auth_tkt)
 
-from time import time
-import Cookie
 import binascii
 import hashlib
 import socket
 import struct
+from time import time
+
+from six.moves import http_cookies
+
+from auth_tkt.compat import base64decode, base64encode, to_bytes
 
 
-def validate(ticket, secret, ip='0.0.0.0', timeout=7200):
+def validate(ticket, secret, ip='0.0.0.0', timeout=7200, encoding='utf-8'):
     """Validate a given authtkt ticket for the secret and ip provided"""
     if len(ticket) < 40:
         return False
@@ -20,7 +24,7 @@ def validate(ticket, secret, ip='0.0.0.0', timeout=7200):
 
     if '!' not in ticket:
         try:
-            raw = ticket.decode('base64')
+            raw = base64decode(ticket, encoding)
             base64 = True
         except binascii.Error:
             return False
@@ -28,7 +32,7 @@ def validate(ticket, secret, ip='0.0.0.0', timeout=7200):
     if '!' not in raw:
         return False
 
-    digest, raw = raw[:32], raw[32:]
+    raw = raw[32:]
     ts, raw = raw[:8], raw[8:]
     uid, extra = raw.split('!', 1)
     tokens = data = ''
@@ -47,7 +51,9 @@ def validate(ticket, secret, ip='0.0.0.0', timeout=7200):
         else:
             data = extra
 
-    auth_ticket = AuthTkt(secret, uid, data, ip, tokens.split(','), base64, ts)
+    auth_ticket = AuthTkt(
+        secret, uid, data, ip, tokens.split(','), base64, ts,
+        encoding=encoding)
     if auth_ticket.ticket() == ticket:
         return auth_ticket
 
@@ -56,10 +62,11 @@ def validate(ticket, secret, ip='0.0.0.0', timeout=7200):
 
 class AuthTkt(object):
     def __init__(self, secret, uid, data='', ip='0.0.0.0', tokens=(),
-                 base64=True, ts=None):
+                 base64=True, ts=None, encoding='utf-8'):
         self.secret = str(secret)
         self.uid = str(uid)
         self.data = data
+        self.encoding = encoding
         self.ip = ip
         self.tokens = ','.join(tok.strip() for tok in tokens)
         self.base64 = base64
@@ -68,12 +75,12 @@ class AuthTkt(object):
     def ticket(self):
         v = self.cookie_value()
         if self.base64:
-            return v.encode('base64').strip().replace('\n', '')
+            return base64encode(v).strip().replace('\n', '')
         return v
 
     def cookie(self, name, **kwargs):
         name = str(name)
-        c = Cookie.SimpleCookie()
+        c = http_cookies.SimpleCookie()
         c[name] = self.ticket()
 
         kwargs.setdefault('path', '/')
@@ -89,12 +96,16 @@ class AuthTkt(object):
         return '!'.join(parts)
 
     def _digest(self):
-        return hashlib.md5(self._digest0() + self.secret).hexdigest()
+        parts = [self._digest0(), self.secret]
+        parts = b''.join([to_bytes(part) for part in parts])
+        return hashlib.md5(parts).hexdigest()
 
     def _digest0(self):
-        parts = (self._encode_ip(self.ip), self._encode_ts(self.ts),
-                 self.secret, self.uid, '\0', self.tokens, '\0', self.data)
-        return hashlib.md5(''.join(parts)).hexdigest()
+        parts = (
+            self._encode_ip(self.ip), self._encode_ts(self.ts),
+            to_bytes(self.secret), to_bytes(self.uid), b'\0',
+            to_bytes(self.tokens), b'\0', to_bytes(self.data))
+        return hashlib.md5(b''.join(parts)).hexdigest()
 
     def _encode_ip(self, ip):
         return socket.inet_aton(ip)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-M2Crypto < 1.0.0
+cryptography < 2.0.0
 nose < 2.0.0
 pep8 < 2.0.0
 pyflakes < 1.0.0
+six < 2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ cryptography < 2.0.0
 nose < 2.0.0
 pep8 < 2.0.0
 pyflakes < 1.0.0
-six < 2.0.0

--- a/setup.py
+++ b/setup.py
@@ -10,5 +10,5 @@ setup(
     url='http://github.com/yola/auth_tkt',
     packages=['auth_tkt'],
     test_suite='nose.collector',
-    install_requires=['cryptography < 2.0.0', 'six < 2.0.0']
+    install_requires=['cryptography < 2.0.0']
 )

--- a/setup.py
+++ b/setup.py
@@ -10,5 +10,5 @@ setup(
     url='http://github.com/yola/auth_tkt',
     packages=['auth_tkt'],
     test_suite='nose.collector',
-    install_requires=['M2Crypto < 1.0.0']
+    install_requires=['cryptography < 2.0.0', 'six < 2.0.0']
 )

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -1,0 +1,27 @@
+from auth_tkt import compat
+from unittest import TestCase
+
+
+class Base64DecodeTestCase(TestCase):
+
+    def test_returns_decoded_string(self):
+        self.assertEqual(
+            compat.base64decode('ZGVjb2RlZA=='), 'decoded')
+
+
+class Base64EncodeTestCase(TestCase):
+
+    def test_encodes_passed_string(self):
+        self.assertEqual(
+            compat.base64encode('decoded'), 'ZGVjb2RlZA==')
+
+
+class ToBytesTestCase(TestCase):
+
+    def test_returns_encoded_byte_string(self):
+        returns = compat.to_bytes('test')
+        self.assertIsInstance(returns, bytes)
+        self.assertEqual(returns, b'test')
+
+    def test_encodes_unicode_strings(self):
+        self.assertEqual(compat.to_bytes(u'\u2603'), b'\xe2\x98\x83')

--- a/tests/test_encrypted.py
+++ b/tests/test_encrypted.py
@@ -1,4 +1,8 @@
+import json
+import base64
 import unittest
+
+from cryptography.hazmat.primitives.ciphers import algorithms
 
 from auth_tkt.ticket import AuthTkt
 from auth_tkt.encrypted import (EncryptedAuthTkt, DecryptionError,
@@ -34,37 +38,39 @@ class EncryptedAuthTktTests(unittest.TestCase):
 
 
 class DataEncryptionTests(unittest.TestCase):
-    cleartext = 'this is a secret message'
-    ciphertext = ('tJzLGOp95tK4YMCy+PTmq3vJ/qT+MCFjKJC7GpmLJivlmL1WNeaUTUSp9nV'
-                  'FTtyZ419htUd7dZeAM0oHs9Nul6DcR4FxU6U38dYUjMyFtsWsmoMAYQY4PK'
-                  'Zivdw+icFIGIyXzUC8HOVfbnh+cIbJEGj+7kvPOvXxKcThxX64usrYbQ==')
-    secret = 'cryptosecret'
+    cleartext = b'this is a secret message'
+    ciphertext = (
+        b'tJzLGOp95tK4YMCy+PTmq3vJ/qT+MCFjKJC7GpmLJivlmL1WNeaUTUSp9nV'
+        b'FTtyZ419htUd7dZeAM0oHs9Nul6DcR4FxU6U38dYUjMyFtsWsmoMAYQY4PK'
+        b'Zivdw+icFIGIyXzUC8HOVfbnh+cIbJEGj+7kvPOvXxKcThxX64usrYbQ==')
+    secret = b'cryptosecret'
 
     def flip_ciphertext_bit(self, byte, bit=0):
-        ciphertext = self.ciphertext.decode('base64')
-        ciphertext = (ciphertext[:-byte]
-                      + chr(ord(ciphertext[byte]) ^ (2 ** bit))
-                      + ciphertext[byte + 1:])
-        return ''.join(ciphertext.encode('base64').split())
+        ciphertext = bytearray(base64.b64decode(self.ciphertext))
+        ciphertext[byte] = ciphertext[byte] ^ (2 ** bit)
+        return base64.b64encode(ciphertext)
 
     def test_derive_keys_salted(self):
-        salt = self.ciphertext.decode('base64')[16:48]
+        salt = base64.b64decode(self.ciphertext)[16:48]
         hmackey, enckey, salt = _derive_keys(self.ciphertext, salt)
         expected_hmackey = 'xbNKad7dTFt7wNYCxkFLVwXtMuiF9eCKCXt3oabIPj0='
         expected_enckey = '7IJke6/xvQSdz/L1tFrvkBjHGWVD5hn5WneFaXTytT8='
-        self.assertEqual(hmackey, expected_hmackey.decode('base64'))
-        self.assertEqual(enckey, expected_enckey.decode('base64'))
+        self.assertEqual(base64.b64encode(hmackey).decode(), expected_hmackey)
+        self.assertEqual(base64.b64encode(enckey).decode(), expected_enckey)
 
     def test_encrypt_userdata(self):
-        ciphertext = _encrypt_userdata(self.cleartext, self.secret)
-        ciphertext = ciphertext.decode('base64')
+        ciphertext = _encrypt_userdata(
+            self.cleartext, self.secret)
+        ciphertext = base64.b64decode(ciphertext)
         # Hand-wavey are-we-encrypted tests
         self.assertTrue(self.cleartext not in ciphertext)
         self.assertTrue(len(ciphertext) >= len(self.cleartext) + 16 + 32)
 
     def test_decrypt_userdata(self):
-        self.assertEqual(_decrypt_userdata(self.ciphertext, self.secret),
-                         self.cleartext)
+        self.assertEqual(
+            json.loads(_decrypt_userdata(
+                self.ciphertext, self.secret).decode()),
+            self.cleartext.decode())
 
     def test_invalid_contents(self):
         ciphertext = self.flip_ciphertext_bit(byte=128)
@@ -78,11 +84,11 @@ class DataEncryptionTests(unittest.TestCase):
 
 
 class CipherHelperTests(unittest.TestCase):
-    plaintext = 'hello there'
-    ciphertext = 'Z\xed\xc5\xe8\xb2&\x8b0\x8cK\x05'
-    key = '1' * 16
-    iv = '2' * 16
-    alg = 'aes_128_ofb'
+    plaintext = b'hello there'
+    ciphertext = b'Z\xed\xc5\xe8\xb2&\x8b0\x8cK\x05'
+    key = b'1' * 16
+    iv = b'2' * 16
+    alg = algorithms.AES
 
     def test_encipher(self):
         ciphertext = _encipher(self.plaintext, self.key, self.iv, self.alg)

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -14,18 +14,23 @@ class IntegrationTests(unittest.TestCase):
             'DYWFDODM3NXdjS1RTbERVUlVUZlV6TUxWZHRZSVpic0JxeGxuRDgyWHBjeE9ORjZB'
             'Y3pvQjlkNkU0N0xScGVVNjNmUTFpdFhOcFkwRExyUG8xdnlGWUtxZHNRTHBYUHc9P'
             'Q==')
+        # Encoding of the encrypted data
+        self.encoding = 'latin_1'
 
     def test_get_ticket_with_data(self):
         data = get_ticket_data(self.cookie, self.authtkt_secret,
-                               self.crypted_cookie_secret, timeout=0)
+                               self.crypted_cookie_secret, timeout=0,
+                               encoding=self.encoding)
         self.assertEqual(sorted(data), ['id', 'name', 'surname', 'tokens'])
 
     def test_get_ticket_no_decrypt(self):
-        data = get_ticket_data(self.cookie, self.authtkt_secret, timeout=0)
+        data = get_ticket_data(
+            self.cookie, self.authtkt_secret, timeout=0,
+            encoding=self.encoding)
         self.assertEqual(sorted(data), ['id', 'tokens'])
 
     def test_get_ticket_unicode(self):
-        data = get_ticket_data(unicode(self.cookie),
-                               unicode(self.authtkt_secret),
-                               unicode(self.crypted_cookie_secret), 0)
+        data = get_ticket_data(
+            u'%s' % self.cookie, u'%s' % self.authtkt_secret,
+            u'%s' % self.crypted_cookie_secret, 0, encoding=self.encoding)
         self.assertEqual(sorted(data), ['id', 'name', 'surname', 'tokens'])


### PR DESCRIPTION
Replace usage of m2crypto with the [cryptography](https://cryptography.io/en/latest/) library. Migrates existing code to be python2/3 compatible.