### PR TITLE
Bump cryptography

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ python:
     - "2.7"
     - "3.4"
     - "3.5"
+    - "3.6"
+    - "3.7"
+    - "3.8"
 install:
     - pip install -r requirements.txt
 script: python setup.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
     - "2.7"
-    - "3.4"
     - "3.5"
     - "3.6"
     - "3.7"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Changelog
 
-## 0.2.2
+## 0.3.0
 
 * Increased maximum allowed version of Cryptography library.
   Now it requires cryptography < 4.0.
 * Added running tests on Python 3.6-3.8.
+* Stop running tests on Python 3.4.
 
 ## 0.2.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.2.2
+
+* Increased maximum allowed version of Cryptography library.
+  Now it requires cryptography < 4.0.
+* Added running tests on Python 3.6-3.8.
+
 ## 0.2.1
 
 * Increased maximum allowed version of Cryptography library.

--- a/auth_tkt/__init__.py
+++ b/auth_tkt/__init__.py
@@ -1,2 +1,2 @@
 __doc__ = 'Python implementation of mod_auth_tkt cookies'
-__version__ = '0.2.2'
+__version__ = '0.3.0'

--- a/auth_tkt/__init__.py
+++ b/auth_tkt/__init__.py
@@ -1,2 +1,2 @@
 __doc__ = 'Python implementation of mod_auth_tkt cookies'
-__version__ = '0.2.1'
+__version__ = '0.2.2'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-cryptography == 2.0.3
+cryptography == 3.1.1
 nose == 1.3.7
 pep8 == 1.7.0
 pyflakes == 1.5.0

--- a/setup.py
+++ b/setup.py
@@ -15,5 +15,5 @@ setup(
     url='http://github.com/yola/auth_tkt',
     packages=['auth_tkt'],
     test_suite='nose.collector',
-    install_requires=['cryptography < 3.0']
+    install_requires=['cryptography < 4.0']
 )


### PR DESCRIPTION
- Allow using a new version of `cryptography`
- Run tests on Python 3.6-3.8
- Stop running tests on Python 3.4 (cause it can't install `cryptography >= 3.0`)