### PR TITLE
Validate NoneType ticket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.3.1
+* Correct error while validating a ticket.
+
 ## 0.3.0
 
 * Increased maximum allowed version of Cryptography library.

--- a/auth_tkt/__init__.py
+++ b/auth_tkt/__init__.py
@@ -1,2 +1,2 @@
 __doc__ = 'Python implementation of mod_auth_tkt cookies'
-__version__ = '0.3.0'
+__version__ = '0.3.1'

--- a/auth_tkt/ticket.py
+++ b/auth_tkt/ticket.py
@@ -21,7 +21,7 @@ from auth_tkt.compat import base64decode, base64encode, to_bytes
 
 def validate(ticket, secret, ip='0.0.0.0', timeout=7200, encoding='utf-8'):
     """Validate a given authtkt ticket for the secret and ip provided"""
-    if len(ticket) < 40:
+    if not ticket or len(ticket) < 40:
         return False
 
     raw = ticket

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -34,3 +34,9 @@ class IntegrationTests(unittest.TestCase):
             u'%s' % self.cookie, u'%s' % self.authtkt_secret,
             u'%s' % self.crypted_cookie_secret, 0, encoding=self.encoding)
         self.assertEqual(sorted(data), ['id', 'name', 'surname', 'tokens'])
+
+    def test_get_none_ticket(self):
+        data = get_ticket_data(
+            None, self.authtkt_secret, self.crypted_cookie_secret,
+            timeout=0, encoding=self.encoding)
+        self.assertEqual(data, None)


### PR DESCRIPTION
Relates to https://github.com/yola/production/issues/8281

Fixes: https://sentry.io/organizations/yola/issues/1929783261/?project=14218&referrer=slack

```python
TypeError: object of type 'NoneType' has no len()
  File "django/core/handlers/exception.py", line 41, in inner
    response = get_response(request)
  File "django/core/handlers/base.py", line 249, in _legacy_get_response
    response = self._get_response(request)
  File "django/core/handlers/base.py", line 187, in _get_response
    response = self.process_exception_by_middleware(e, request)
  File "django/core/handlers/base.py", line 185, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "django/utils/decorators.py", line 185, in inner
    return func(*args, **kwargs)
  File "django/views/decorators/csrf.py", line 58, in wrapped_view
    return view_func(*args, **kwargs)
  File "rest_framework/viewsets.py", line 83, in view
    return self.dispatch(request, *args, **kwargs)
  File "rest_framework/views.py", line 483, in dispatch
    response = self.handle_exception(exc)
  File "rest_framework/views.py", line 443, in handle_exception
    self.raise_uncaught_exception(exc)
  File "rest_framework/views.py", line 480, in dispatch
    response = handler(request, *args, **kwargs)
  File "profile/views.py", line 143, in from_cookie
    return self.retrieve(request, **kwargs)
  File "profile/views.py", line 130, in retrieve
    cookie, settings.SECRET, settings.CRYPTO_SECRET)
  File "auth_tkt/helpers.py", line 10, in get_ticket_data
    ticket, authtkt_secret, timeout=timeout, encoding=encoding)
  File "auth_tkt/ticket.py", line 24, in validate
    if len(ticket) < 40:
```