### PR TITLE
Restrict vulnerable versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.3.1
+
+* Add restrictions on `cryptography` package to avoid 
+  [CVE-2020-25659](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-25659).
+  python-cryptography 3.2 is vulnerable to Bleichenbacher timing attacks in the
+  RSA decryption API, via timed processing of valid PKCS#1 v1.5 ciphertext. 
+
 ## 0.3.0
 
 * Increased maximum allowed version of Cryptography library.

--- a/auth_tkt/__init__.py
+++ b/auth_tkt/__init__.py
@@ -1,2 +1,2 @@
 __doc__ = 'Python implementation of mod_auth_tkt cookies'
-__version__ = '0.3.0'
+__version__ = '0.3.1'

--- a/setup.py
+++ b/setup.py
@@ -15,5 +15,5 @@ setup(
     url='http://github.com/yola/auth_tkt',
     packages=['auth_tkt'],
     test_suite='nose.collector',
-    install_requires=['cryptography < 4.0']
+    install_requires=['cryptography >=3.3 ,< 4.0']
 )


### PR DESCRIPTION
I've run a vulnerability scanner locally and found the security issue with cryptography library. Not related to any ticket.