### PR TITLE
Add support for sha256 and sha512 hashing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3.1
+
+* Added support for `sha256` and `sha512` digests.
+
 ## 0.3.0
 
 * Increased maximum allowed version of Cryptography library.

--- a/auth_tkt/ticket.py
+++ b/auth_tkt/ticket.py
@@ -37,7 +37,8 @@ def validate(ticket, secret, ip='0.0.0.0', timeout=7200, encoding='utf-8', diges
     if '!' not in raw:
         return False
 
-    raw = raw[32:]
+    hash_length = hashlib.new(digest).digest_size * 2
+    raw = raw[hash_length:]
     ts, raw = raw[:8], raw[8:]
     uid, extra = raw.split('!', 1)
     tokens = data = ''

--- a/tests/test_ticket.py
+++ b/tests/test_ticket.py
@@ -199,3 +199,10 @@ class ValidateTests(unittest.TestCase):
     def test_wrong_userdata_b64(self):
         body = self.build_ticket(data=b'!' * 32, base64encode=True)
         self.assertFalse(validate(body, self.secret, timeout=0))
+        
+    def test_various_digest_types(self):
+        for digest in ('md5', 'sha256', 'sha512'):
+            tkt = AuthTkt(self.secret, 'uid',
+                digest=digest, base64=False)
+            self.assertTrue(validate(tkt.cookie_value(), self.secret,
+                digest=digest), "%s validation failed" % digest)


### PR DESCRIPTION
MD5 is [insecure](https://security.stackexchange.com/questions/19906/is-md5-considered-insecure/19908#19908), and [mod_auth_tkt](http://manpages.ubuntu.com/manpages/focal/en/man3/mod_auth_tkt.3.html) supports `sha256` and `sha512` hashes. This PR adds a configuration option for the hash algorithm.
